### PR TITLE
Fixes from CI run on Friday 22 July 2022

### DIFF
--- a/connectors/koha/v22.js
+++ b/connectors/koha/v22.js
@@ -31,7 +31,7 @@ exports.getLibraries = async function (service) {
     let $ = cheerio.load(libraryPageRequest.text)
   
     $('option').each((idx, option) => {
-        if (option.attribs["value"].startsWith('owning_location_main:') && common.isLibrary($(option).text().trim()))
+        if ((option.attribs["value"].startsWith('owning_location_main:') || option.attribs["value"].startsWith('owning_location:')) && common.isLibrary($(option).text().trim()))
             responseLibraries.libraries.push($(option).text().trim());
     })
   }

--- a/data/data.json
+++ b/data/data.json
@@ -1601,7 +1601,8 @@
       "Id": "320001",
       "Url": "https://library.telford.gov.uk/web/arena/",
       "AdvancedUrl": "extended-search",
-      "OrganisationId": "AUK000032|0"
+      "OrganisationId": "AUK000032|0",
+      "OrganisationName": "wrekin"
     },
     {
       "Name": "Thurrock",


### PR DESCRIPTION
* Telford and Wrekin - needed a config change in data.json.
* Newcastle Upon Tyne and Sefton - Koha v22 change required to support a minor change in the platform's library listings.