### PR TITLE
Resolves GitHub Actions issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: CI
-on: workflow_dispatch
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 13 * * 5" # Every Friday at 13:00 UTC
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,6 @@
 name: CI
 on:
+  on: workflow_dispatch
   schedule:
     - cron: "0 13 * * 5" # Every Friday at 13:00 UTC
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: CI
+on: workflow_dispatch
 on:
-  on: workflow_dispatch
   schedule:
     - cron: "0 13 * * 5" # Every Friday at 13:00 UTC
 jobs:

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const async = require('async')
 const data = require('./data/data.json')
 const libThing = require('./connectors/librarything')
 const openLibrary = require('./connectors/openlibrary')
-const syswidecas = require('syswide-cas');
+const syswidecas = require('./syswide-cas.js');
 
 // Intermediate certificate that's often incomplete in SSL chains.
 syswidecas.addCAs('./SectigoRSADomainValidationSecureServerCA.cer');

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "cheerio": "^1.0.0-rc.12",
         "node-polyfill-webpack-plugin": "^2.0.1",
         "superagent": "^8.0.0",
-        "syswide-cas": "^5.3.0",
         "tough-cookie": "^4.0.0",
         "uuid": "^8.3.2",
         "xml2js": "^0.4.23"
@@ -5433,14 +5432,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/syswide-cas": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/syswide-cas/-/syswide-cas-5.3.0.tgz",
-      "integrity": "sha512-+RLgS6VInsX8rBpL+gy5qpa7phngecbK7NABelBZpqYpBTwOIK1y7CqHlXK5Vy/rA4erD9q/FyKzMjx2uX3zYg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -10155,11 +10146,6 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
-    },
-    "syswide-cas": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/syswide-cas/-/syswide-cas-5.3.0.tgz",
-      "integrity": "sha512-+RLgS6VInsX8rBpL+gy5qpa7phngecbK7NABelBZpqYpBTwOIK1y7CqHlXK5Vy/rA4erD9q/FyKzMjx2uX3zYg=="
     },
     "tapable": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "cheerio": "^1.0.0-rc.12",
     "node-polyfill-webpack-plugin": "^2.0.1",
     "superagent": "^8.0.0",
-    "syswide-cas": "^5.3.0",
     "tough-cookie": "^4.0.0",
     "uuid": "^8.3.2",
     "xml2js": "^0.4.23"

--- a/syswide-cas.js
+++ b/syswide-cas.js
@@ -1,0 +1,102 @@
+const fs = require("fs");
+const path = require("path");
+const tls = require("tls");
+
+const rootCAs = [];
+
+// for node 7.2 and up, trapping method must be used.
+var useTrap = false;
+const parts = process.versions.node.split(".");
+const major = parseInt(parts[0]);
+const minor = parseInt(parts[1]);
+if (major > 7 || (major == 7 && minor >= 2) || (major === 6 && minor >= 10)) {
+  useTrap = true;
+}
+
+// create an empty secure context loaded with the root CAs
+const rootSecureContext = tls.createSecureContext ? tls.createSecureContext() : require("crypto").createCredentials();
+
+function addDefaultCA(file) {
+  try {
+    var cert, match;
+    var content = fs.readFileSync(file, { encoding: "ascii" }).trim();
+    content = content.replace(/\r\n/g, "\n"); // Handles certificates that have been created in Windows
+    var regex = /-----BEGIN CERTIFICATE-----\n[\s\S]+?\n-----END CERTIFICATE-----/g;
+    var results = content.match(regex);
+    if (!results) throw new Error("Could not parse certificate");
+    results.forEach(function(match) {
+      var cert = match.trim();
+      rootCAs.push(cert);
+      // this will add the cert to the root certificate authorities list
+      // which will be used by all subsequent secure contexts with root CAs.
+      // this only works up to node 6. node 7 and up it has no affect.
+      if (!useTrap) {
+        rootSecureContext.context.addCACert(cert);
+      }
+    });
+  } catch (e) {
+    if (e.code !== "ENOENT") {
+      console.log("failed reading file " + file + ": " + e.message);
+    }
+  }
+}
+
+exports.addCAs = function(dirs) {
+  if (!dirs) {
+    return;
+  }
+
+  if (typeof dirs === "string") {
+    dirs = dirs.split(",").map(function(dir) {
+      return dir.trim();
+    });
+  }
+
+  var files, stat, file, i, j;
+  for (i = 0; i < dirs.length; ++i) {
+    try {
+      stat = fs.statSync(dirs[i]);
+      if (stat.isDirectory()) {
+        files = fs.readdirSync(dirs[i]);
+        for (j = 0; j < files.length; ++j) {
+          file = path.resolve(dirs[i], files[j]);
+          try {
+            stat = fs.statSync(file);
+            if (stat.isFile()) {
+              addDefaultCA(file);
+            }
+          } catch (e) {
+            if (e.code !== "ENOENT") {
+              console.log("failed reading " + file + ": " + e.message);
+            }
+          }
+        }
+      } else {
+        addDefaultCA(dirs[i]);
+      }
+    } catch (e) {
+      if (e.code !== "ENOENT") {
+        console.log("failed reading " + dirs[i] + ": " + e.message);
+      }
+    }
+  }
+};
+
+if (useTrap) {
+  // trap the createSecureContext method and inject custom root CAs whenever invoked
+  const origCreateSecureContext = tls.createSecureContext;
+  tls.createSecureContext = function(options) {
+    var c = origCreateSecureContext.apply(null, arguments);
+    if (!options?.ca && rootCAs.length > 0) {
+      rootCAs.forEach(function(ca) {
+        // add to the created context our own root CAs
+        c.context.addCACert(ca);
+      });
+    }
+    return c;
+  };
+}
+
+const defaultCALocations = ["/etc/ssl/ca-node.pem"];
+
+exports.addCAs(defaultCALocations);


### PR DESCRIPTION
## Fixed GitHub Action crash

The last change introduced use of the `syswide-cas` npm package to load a missing certificate from several library services' CA chains. Unfortunately, this also created a classic "works on my computer" situation for the tests; worked for me but they *failed* to run on GitHub Actions.

The problem was within the `syswide-cas` package which was assuming an object used in its internals couldn't be `undefined` and yet it *was* on the GitHub Action agent. 

Since the `syswide-cas` code is just a single file, I have temporarily brought that file directly into this repo and have made the necessary tweak. I have also [raised an issue](https://github.com/small-tech/syswide-cas/issues/1) on the original repo in the hope that this can be fixed and we can revert to referencing a public package.

## Added GitHub Action Trigger

In addition to running on a schedule, the action can now be run manually via the GitHub UI.

## Caveats

At the time of making these commits, Coventry's library catalogue appears to be down so its test is failing. There isn't any indication that they've switched to a new provider or URL, so I'm hoping this is just a transient problem. I eventually receive this error:

```
This is the Server Unavailable Error page called by the CSP Gateway
```

Bury's test has also been failing itermittently, which also implies an availability issue. Again, I'm hoping this is just a transient problem.