### PR TITLE
Test failures from 16/09/2022

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -1242,7 +1242,7 @@
       "Name": "Plymouth",
       "Code": "E06000026",
       "Type": "arena",
-      "Version": "v6",
+      "Version": "v7",
       "ArenaName": "AUK770000",
       "AdvancedUrl": "extended-search",
       "OrganisationId": "AUK770000|1",


### PR DESCRIPTION
The Plymouth test failed today. This is because they've moved to v7 of Arena.

`data.json` has been updated accordingly and the test now passed on my machine.