### PR TITLE
Bury to Spydus; Luci tests require VPN

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,16 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install modules
       run: npm install
-    - name: Install and Launch OpenVPN
+    - name: Install OpenVPN
       run: |
         curl ${{ secrets.OVPN_URL }} --output config.ovpn --silent
-        sudo apt-get update
-        sudo apt-get --assume-yes --no-install-recommends install openvpn 
-        sudo openvpn --config "config.ovpn" --auth-user-pass <(echo -e ${{ secrets.OVPN_USERNAME }}"\n"${{ secrets.OVPN_PASSWORD }}) --daemon
+        sudo apt update
+        sudo apt install -y openvpn openvpn-systemd-resolved
+    - name: Connect to VPN
+      uses: "kota65535/github-openvpn-connect-action@v2"
+      with:
+        config_file: config.ovpn
+        username: ${{ secrets.OVPN_USERNAME }}
+        password: ${{ secrets.OVPN_PASSWORD }}
     - name: Run tests
       run: npm run test-ci
-    - name: Close OpenVPN
-      run: |
-        sudo killall openvpn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,11 @@ jobs:
     - name: Install modules
       run: npm install
     - name: Install and Launch OpenVPN
-        run: |
-          curl ${{ secrets.OVPN_URL }} --output config.ovpn --silent
-          sudo apt-get update
-          sudo apt-get --assume-yes --no-install-recommends install openvpn 
-          sudo openvpn --config "config.ovpn" --auth-user-pass <(echo -e ${{ secrets.OVPN_USERNAME }}"\n"${{ secrets.OVPN_PASSWORD }}) --daemon
+      run: |
+        curl ${{ secrets.OVPN_URL }} --output config.ovpn --silent
+        sudo apt-get update
+        sudo apt-get --assume-yes --no-install-recommends install openvpn 
+        sudo openvpn --config "config.ovpn" --auth-user-pass <(echo -e ${{ secrets.OVPN_USERNAME }}"\n"${{ secrets.OVPN_PASSWORD }}) --daemon
     - name: Run tests
       run: npm run test-ci
     - name: Close OpenVPN

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,5 +10,14 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install modules
       run: npm install
+    - name: Install and Launch OpenVPN
+        run: |
+          curl ${{ secrets.OVPN_URL }} --output config.ovpn --silent
+          sudo apt-get update
+          sudo apt-get --assume-yes --no-install-recommends install openvpn 
+          sudo openvpn --config "config.ovpn" --auth-user-pass <(echo -e ${{ secrets.OVPN_USERNAME }}"\n"${{ secrets.OVPN_PASSWORD }}) --daemon
     - name: Run tests
       run: npm run test-ci
+    - name: Close OpenVPN
+        run: |
+          sudo killall openvpn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,5 @@ jobs:
     - name: Run tests
       run: npm run test-ci
     - name: Close OpenVPN
-        run: |
-          sudo killall openvpn
+      run: |
+        sudo killall openvpn

--- a/data/data.json
+++ b/data/data.json
@@ -218,12 +218,8 @@
     {
       "Name": "Bury",
       "Code": "E08000002",
-      "Type": "enterprise",
-      "Available": [
-        "In stock"
-      ],
-      "TitleDetailUrl": "search/detailnonmodal.detail.detailavailabilityaccordions:lookuptitleinfo/ent:[ITEMID]/ILS/0/true/true",
-      "Url": "https://bury.ent.sirsidynix.net.uk/client/en_GB/default/"
+      "Type": "spydus",
+      "Url": "https://bury.spydus.co.uk/"
     },
     {
       "Name": "Caerphilly",

--- a/tests/enterprise.test.js
+++ b/tests/enterprise.test.js
@@ -9,7 +9,6 @@ test('E08000032 - Bradford', async () => await index.runTest('Bradford'), 300000
 test('E09000005 - Brent', async () => await index.runTest('Brent'), 300000);
 test('W06000013 - Pen-y-bont ar Ogwr - Bridgend', async () => await index.runTest('Pen-y-bont ar Ogwr - Bridgend'), 300000);
 test('E06000023 - Bristol City', async () => await index.runTest('Bristol City'), 300000);
-test('E08000002 - Bury', async () => await index.runTest('Bury'), 300000);
 test('W06000018 - Caerphilly', async () => await index.runTest('Caerphilly'), 300000);
 test('W06000015 - Caerdydd - Cardiff', async () => await index.runTest('Caerdydd - Cardiff'), 300000);
 test('W06000010 - Sir Gaerfyrddin - Carmarthenshire', async () => await index.runTest('Sir Gaerfyrddin - Carmarthenshire'), 300000);

--- a/tests/spydus.test.js
+++ b/tests/spydus.test.js
@@ -9,6 +9,7 @@ test('E06000008 - Blackburn with Darwen', async () => await index.runTest('Black
 test('E08000001 - Bolton', async () => await index.runTest('Bolton'), 300000);
 test('E06000043 - Brighton and Hove', async () => await index.runTest('Brighton and Hove'), 300000);
 test('E10000002 - Buckinghamshire', async () => await index.runTest('Buckinghamshire'), 300000);
+test('E08000002 - Bury', async () => await index.runTest('Bury'), 300000);
 test('E08000033 - Calderdale', async () => await index.runTest('Calderdale'), 300000);
 test('E10000003 - Cambridgeshire', async () => await index.runTest('Cambridgeshire'), 300000);
 test('E09000007 - Camden', async () => await index.runTest('Camden'), 300000);


### PR DESCRIPTION
# Bury

Has moved to Spydus. `data.json` updated and test passes.

# Test automation and Luci

## The problem

We've hit a bit of a problem with the tests for Luci. They've failed the last two weeks but worked fine on my computer. My theory was that connections from outside the UK are being blocked by their servers, and I've now confirmed that by trying to run the tests when connected to a VPN to the US.

It's not possible to choose a region to run a GitHub Action in. All GitHub's servers are in the US.

## Updates to the Action

I've updated the YAML file for the GitHub action so it launches an OpenVPN connection to a server prior to the tests running. The URL for the connection profile, the username and the password can be stored as secrets in the repository's configuration. For my fork of the repo, I'm using my Express VPN credentials to access their UK server prior to running the tests. The Luci tests do now pass.

## Ways forward

Unfortunately, this has added a bit of complexity to something that really ought to be far more straightforward!

Since I'd rather not share my ExpressVPN credentials (sorry!), I guess there are the following ways forward:

1. You could disable the Action in the LibrariesHacked and I'll just keep it running in my fork. I'll continue to do fixes as and when required.
2. You could use your own connection profile, username and password in the LibrariesHacked origin.

Also open to other ideas..!