### PR TITLE
Enterprise config fixes for Barnsley and Rotherham

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -62,7 +62,7 @@
       "Available": [
         "In stock"
       ],
-      "TitleDetailUrl": "search/detailnonmodal.detail.detailavailabilityaccordions:lookuptitleinfo/ent:[ITEMID]/ILS/0/true/true"
+      "AvailabilityUrl": "search/detailnonmodal.detail.detailavailabilityaccordions:lookuptitleinfo/ent:[ITEMID]/ILS/0/true/true"
     },
     {
       "Name": "Bath and North East Somerset",
@@ -1324,7 +1324,7 @@
       "Available": [
         "Available"
       ],
-      "TitleDetailUrl": "search/detailnonmodal.detail.detailavailabilityaccordions:lookuptitleinfo/ent:[ITEMID]/ILS/0/true/true",
+      "AvailabilityUrl": "search/detailnonmodal.detail.detailavailabilityaccordions:lookuptitleinfo/ent:[ITEMID]/ILS/0/true/true",
       "Url": "https://rotherham.ent.sirsidynix.net.uk/client/en_GB/default/"
     },
     {


### PR DESCRIPTION
Further changes for Enterprise customers, following from the previous PR.

North Lanarkshire test is currently failing because the catalogue is down for maintenance.